### PR TITLE
Update dependencies

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.3/apache-maven-3.9.3-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.4/apache-maven-3.9.4-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:17-jre
 # Add Maven dependencies (not shaded into the artifact; Docker-cached)
 ADD /target/lib  /lib
 ARG JAR_FILE

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+./mvnw clean verify -DskipTests
+docker build --build-arg="JAR_FILE=/target/composer.jar" --build-arg="CONF_FILE=/composer.conf" --tag="kotlin-workshop/composer-service:latest" .

--- a/pom.xml
+++ b/pom.xml
@@ -227,27 +227,42 @@
                     </execution>
                 </executions>
             </plugin>
-
-            <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
-                <version>${dockerfile-maven-version}</version>
-                <executions>
-                    <execution>
-                        <id>default</id>
-                        <goals>
-                            <goal>build</goal>
-                        </goals>
-                        <configuration>
-                            <repository>${docker.image.prefix}/${project.artifactId}</repository>
-                            <buildArgs>mv
-                                <JAR_FILE>/target/${composer.jar-file}</JAR_FILE>
-                                <CONF_FILE>/composer.conf</CONF_FILE>
-                            </buildArgs>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>docker</id>
+            <activation>
+                <os>
+                    <arch>!aarch64</arch>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.spotify</groupId>
+                        <artifactId>dockerfile-maven-plugin</artifactId>
+                        <version>${dockerfile-maven-version}</version>
+                        <executions>
+                            <execution>
+                                <id>default</id>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                                <configuration>
+                                    <repository>${docker.image.prefix}/${project.artifactId}</repository>
+                                    <buildArgs>
+                                        <JAR_FILE>/target/${composer.jar-file}</JAR_FILE>
+                                        <CONF_FILE>/composer.conf</CONF_FILE>
+                                    </buildArgs>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
         <dockerfile-maven-version>1.4.13</dockerfile-maven-version>
 
-        <docker.image.prefix>inova-workshop</docker.image.prefix>
+        <docker.image.prefix>kotlin-workshop</docker.image.prefix>
         <composer.jar-file>composer.jar</composer.jar-file>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.5</version>
+                <version>0.8.8</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
- Bump wrapped Maven version to 3.9.4
- Bump jacoco-maven-plugin to support Java 17
- Adjust Docker image name for Kotlin workshop
- Add support for Docker on aarch64
